### PR TITLE
Fix partial title search logic in TutorialService

### DIFF
--- a/src/main/java/com/bezkoder/spring/restapi/service/TutorialService.java
+++ b/src/main/java/com/bezkoder/spring/restapi/service/TutorialService.java
@@ -18,8 +18,16 @@ public class TutorialService {
   }
 
   public List<Tutorial> findByTitleContaining(String title) {
-    return tutorials.stream().filter(tutorial -> tutorial.getTitle().contains(title)).toList();
+    if (title == null || title.isEmpty()) {
+      return tutorials; // return all if no title is provided
+    }
+    String lowerCaseTitle = title.toLowerCase();
+    return tutorials.stream()
+            .filter(tutorial -> tutorial.getTitle() != null &&
+                    tutorial.getTitle().toLowerCase().contains(lowerCaseTitle))
+            .toList();
   }
+
 
   public Tutorial findById(long id) {
     return tutorials.stream().filter(tutorial -> id == tutorial.getId()).findAny().orElse(null);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@
 # ===============================
 # Server Configuration
 # ===============================
-server.port=8081       
+server.port=8081
 
 # ===============================
 # Database Configuration


### PR DESCRIPTION
**Description:**
This pull request fixes the partial title search functionality in the Tutorials API.

Updated TutorialService.findByTitleContaining() to correctly filter tutorials containing the search term.

Verified the /api/tutorials?title=<keyword> endpoint returns correct results for partial matches.

No changes were made to other endpoints; all existing functionality remains intact.

**Testing:**
<img width="960" height="403" alt="Screenshot 2025-08-27 152458" src="https://github.com/user-attachments/assets/fd381f73-2672-4b6b-bb80-0eec9add9317" />
<img width="960" height="412" alt="Screenshot 2025-08-27 152521" src="https://github.com/user-attachments/assets/cee78f54-38bd-45c8-996c-9b8adeab2ce2" />


Added test tutorials via POST requests.

Verified GET requests with partial titles return expected tutorials.

Manual tests confirmed correct search behavior.

Impact:
This fix resolves the 400 Bad Request issue when searching tutorials by partial titles.